### PR TITLE
Add WeightParallelizedTensor support in TR optimizers

### DIFF
--- a/src/dd4ml/optimizers/lssr1_tr.py
+++ b/src/dd4ml/optimizers/lssr1_tr.py
@@ -7,6 +7,7 @@ import torch
 import torch.distributed as dist
 from torch import Tensor
 from torch.optim.optimizer import Optimizer
+from dd4ml.pmw.weight_parallelized_tensor import WeightParallelizedTensor
 
 from dd4ml.solvers.obs import OBS
 from dd4ml.utility.optimizer_utils import solve_tr_first_order, solve_tr_second_order
@@ -391,6 +392,8 @@ class LSSR1_TR(Optimizer):
         # Evaluate or retrieve precomputed loss and gradient
         loss = _["loss"] if "loss" in _ else closure(compute_grad=True)
         g = _["grad"] if "grad" in _ else self._flatten_grads()
+        if isinstance(g, WeightParallelizedTensor):
+            g = g.detach()
         gn = torch.norm(g, p=self.norm_type)
         if self.sync and self.world_size > 1:
             loss = self._avg_scalar(loss)

--- a/src/dd4ml/optimizers/tr.py
+++ b/src/dd4ml/optimizers/tr.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import Iterable, Tuple
 import torch
 from torch.optim import Optimizer
+from dd4ml.pmw.weight_parallelized_tensor import WeightParallelizedTensor
 from dd4ml.optimizers.lsr1 import LSR1
 from dd4ml.solvers.obs import OBS
 from dd4ml.utility import (
@@ -88,6 +89,8 @@ class TR(Optimizer):
         # Evaluate loss and gradient
         loss = _["loss"] if "loss" in _ else closure(compute_grad=True)
         grad = _["grad"] if "grad" in _ else self._flat_grad()
+        if isinstance(grad, WeightParallelizedTensor):
+            grad = grad.detach()
         gn = torch.norm(grad, p=self.norm_type)
 
         # Convergence test


### PR DESCRIPTION
## Summary
- extend trust region solvers to accept `WeightParallelizedTensor`
- detach WeightParallelizedTensor inputs in `TR` and `LSSR1_TR`

## Testing
- `python -m compileall -q src/dd4ml/optimizers/lssr1_tr.py src/dd4ml/optimizers/tr.py src/dd4ml/utility/optimizer_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6841a0c588088322b63375778de02ec3