### PR TITLE
Allow selecting optimizers from config

### DIFF
--- a/src/dd4ml/utility/trainer_setup.py
+++ b/src/dd4ml/utility/trainer_setup.py
@@ -44,6 +44,13 @@ def get_config_model_and_trainer(args, wandb_config):
     else:
         args.pop("sweep_config", None)
     all_config.merge_from_dict(args)
+
+    # Allow `subdomain_opt` as an alias for `loc_opt` in configuration files
+    if hasattr(all_config.trainer, "subdomain_opt") and not hasattr(
+        all_config.trainer, "loc_opt"
+    ):
+        all_config.trainer.loc_opt = all_config.trainer.subdomain_opt
+        delattr(all_config.trainer, "subdomain_opt")
     all_config.merge_and_cleanup(keys_to_look=["system", "model", "trainer"])
 
     # Instantiate dataset.

--- a/tests/config_files/config_apts_d.yaml
+++ b/tests/config_files/config_apts_d.yaml
@@ -59,3 +59,7 @@ parameters:
     value: 3
   max_wolfe_iters:
     value: 10
+  glob_opt:
+    value: "lssr1_tr"
+  subdomain_opt:
+    value: "tr"

--- a/tests/config_files/config_apts_ip.yaml
+++ b/tests/config_files/config_apts_ip.yaml
@@ -60,4 +60,6 @@ parameters:
   max_wolfe_iters:
     value: 10
   glob_opt:
-    value: "asntr"
+    value: "lssr1_tr"
+  subdomain_opt:
+    value: "sgd"

--- a/tests/config_files/config_apts_p.yaml
+++ b/tests/config_files/config_apts_p.yaml
@@ -59,3 +59,7 @@ parameters:
     value: 3
   max_wolfe_iters:
     value: 10
+  glob_opt:
+    value: "lssr1_tr"
+  subdomain_opt:
+    value: "tr"


### PR DESCRIPTION
## Summary
- support alias `subdomain_opt` in trainer setup
- parse `glob_opt` and `loc_opt` strings in APTS optimizers
- update example config files with `glob_opt` and `subdomain_opt`

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846cffe5f188322b77437719bb59781