### PR TITLE
Normalize optimizer option strings

### DIFF
--- a/tests/run_config_file.py
+++ b/tests/run_config_file.py
@@ -143,7 +143,13 @@ def parse_cmd_args() -> argparse.Namespace:
             help="Max iterations for local optimizer",
         )
 
-    return parser.parse_args()
+    args = parser.parse_args()
+    args.optimizer = args.optimizer.lower()
+    if hasattr(args, "glob_opt") and isinstance(args.glob_opt, str):
+        args.glob_opt = args.glob_opt.lower()
+    if hasattr(args, "loc_opt") and isinstance(args.loc_opt, str):
+        args.loc_opt = args.loc_opt.lower()
+    return args
 
 
 def wait_and_exit(rank: int) -> None:


### PR DESCRIPTION
## Summary
- normalize `optimizer`, `glob_opt`, and `loc_opt` strings in `trainer_setup`
- parse CLI optimizer options in lowercase

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846d590a8ec83229f392486b7183c24