### PR TITLE
Add 2D Poisson PINN example

### DIFF
--- a/src/dd4ml/datasets/pinn_poisson2d.py
+++ b/src/dd4ml/datasets/pinn_poisson2d.py
@@ -1,0 +1,43 @@
+import torch
+
+from .base_dataset import BaseDataset
+
+class Poisson2DDataset(BaseDataset):
+    """Dataset for 2D Poisson equation ``-\Delta u = f`` on [0,1]^2 with zero boundary conditions."""
+
+    @staticmethod
+    def get_default_config():
+        C = BaseDataset.get_default_config()
+        C.n_interior = 1000
+        C.n_boundary_side = 20
+        C.low = 0.0
+        C.high = 1.0
+        return C
+
+    def __init__(self, config, data=None, transform=None):
+        super().__init__(config, data, transform)
+        self._generate_points()
+
+    def _generate_points(self):
+        cfg = self.config
+        low, high = cfg.low, cfg.high
+        # interior points sampled uniformly
+        interior = torch.rand(cfg.n_interior, 2) * (high - low) + low
+        # boundary points along each side
+        t = torch.linspace(low, high, cfg.n_boundary_side)
+        left = torch.stack([torch.full_like(t, low), t], dim=1)
+        right = torch.stack([torch.full_like(t, high), t], dim=1)
+        bottom = torch.stack([t, torch.full_like(t, low)], dim=1)
+        top = torch.stack([t, torch.full_like(t, high)], dim=1)
+        boundary = torch.cat([left, right, bottom, top], dim=0)
+        self.x_interior = interior
+        self.x_boundary = boundary
+        self.data = torch.cat([interior, boundary], dim=0)
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        xy = self.data[idx]
+        is_boundary = 1.0 if idx >= len(self.x_interior) else 0.0
+        return xy, torch.tensor([is_boundary], dtype=torch.float32)

--- a/src/dd4ml/trainer.py
+++ b/src/dd4ml/trainer.py
@@ -18,6 +18,7 @@ from torch.utils.data.distributed import DistributedSampler
 
 from dd4ml.pmw.weight_parallelized_tensor import WeightParallelizedTensor
 from dd4ml.datasets.pinn_poisson import Poisson1DDataset
+from dd4ml.datasets.pinn_poisson2d import Poisson2DDataset
 from dd4ml.utility import CfgNode as CN
 from dd4ml.utility import closure, dprint
 
@@ -375,7 +376,7 @@ class Trainer:
 
     def run(self):
         self.setup_data_loaders()
-        if isinstance(self.train_dataset, Poisson1DDataset):
+        if isinstance(self.train_dataset, (Poisson1DDataset, Poisson2DDataset)):
             self.run_by_epoch_PINN()
         elif self.config.run_by_epoch:
             self.run_by_epoch()
@@ -458,7 +459,7 @@ class Trainer:
 
     def compute_accuracy(self):
         """Compute test accuracy across all processes (and pipeline stages)."""
-        if isinstance(self.test_dataset, Poisson1DDataset):
+        if isinstance(self.test_dataset, (Poisson1DDataset, Poisson2DDataset)):
             self.accuracy = float("nan")
             return
 
@@ -559,8 +560,8 @@ class Trainer:
         x, y = x.to(self.device), y.to(self.device)
         bs = y.size(0)
 
-        # Special handling for Poisson1D PINN dataset
-        if isinstance(self.train_dataset, Poisson1DDataset):
+        # Special handling for PINN datasets
+        if isinstance(self.train_dataset, (Poisson1DDataset, Poisson2DDataset)):
             return self._train_one_batch_PINN(x, y, first_grad)
 
         # optional control batch for ASNTR

--- a/src/dd4ml/utility/__init__.py
+++ b/src/dd4ml/utility/__init__.py
@@ -10,3 +10,4 @@ from .trainer_setup import *
 from .utils import *
 from .wandb_utils import *
 from .pinn_poisson_loss import PoissonPINNLoss
+from .pinn_poisson2d_loss import Poisson2DPINNLoss

--- a/src/dd4ml/utility/factory.py
+++ b/src/dd4ml/utility/factory.py
@@ -66,6 +66,7 @@ DATASET_MAP = {
     "cifar10": ("dd4ml.datasets.cifar10", "CIFAR10Dataset"),
     "tinyshakespeare": ("dd4ml.datasets.tinyshakespeare", "TinyShakespeareDataset"),
     "poisson1d": ("dd4ml.datasets.pinn_poisson", "Poisson1DDataset"),
+    "poisson2d": ("dd4ml.datasets.pinn_poisson2d", "Poisson2DDataset"),
 }
 
 MODEL_MAP = {
@@ -96,6 +97,10 @@ CRITERION_MAP = {
     "pinn_poisson": (
         "dd4ml.utility.pinn_poisson_loss",
         "PoissonPINNLoss",
+    ),
+    "pinn_poisson2d": (
+        "dd4ml.utility.pinn_poisson2d_loss",
+        "Poisson2DPINNLoss",
     ),
 }
 

--- a/src/dd4ml/utility/pinn_poisson2d_loss.py
+++ b/src/dd4ml/utility/pinn_poisson2d_loss.py
@@ -1,0 +1,29 @@
+import math
+import torch
+import torch.nn as nn
+
+class Poisson2DPINNLoss(nn.Module):
+    """Loss for 2D Poisson PINN with forcing ``f(x,y)=2\pi^2\sin(\pi x)\sin(\pi y)`` and zero Dirichlet boundary."""
+
+    def __init__(self, current_xy=None):
+        super().__init__()
+        self.current_xy = current_xy
+
+    def forward(self, u_pred, boundary_flag):
+        if self.current_xy is None:
+            raise ValueError("current_xy must be set before calling Poisson2DPINNLoss")
+        xy = self.current_xy
+        xy.requires_grad_(True)
+
+        # gradients with respect to x and y
+        grad_u = torch.autograd.grad(u_pred, xy, torch.ones_like(u_pred), create_graph=True)[0]
+        u_x = grad_u[:, 0:1]
+        u_y = grad_u[:, 1:2]
+        grad2_u_x = torch.autograd.grad(u_x, xy, torch.ones_like(u_x), create_graph=True)[0][:, 0:1]
+        grad2_u_y = torch.autograd.grad(u_y, xy, torch.ones_like(u_y), create_graph=True)[0][:, 1:2]
+        laplace_u = grad2_u_x + grad2_u_y
+
+        rhs = 2 * math.pi ** 2 * torch.sin(math.pi * xy[:, 0:1]) * torch.sin(math.pi * xy[:, 1:2])
+        interior = ((-laplace_u - rhs).squeeze()) ** 2 * (1 - boundary_flag.squeeze())
+        boundary = (u_pred.squeeze() ** 2) * boundary_flag.squeeze()
+        return interior.mean() + boundary.mean()

--- a/tests/examples/pinn_poisson2d.py
+++ b/tests/examples/pinn_poisson2d.py
@@ -1,0 +1,14 @@
+from dd4ml.utility import generic_run
+
+if __name__ == "__main__":
+    args = {
+        "dataset_name": "poisson2d",
+        "model_name": "pinn_ffnn",
+        "optimizer": "apts_d",
+        "criterion": "pinn_poisson2d",
+        "epochs": 1000,
+        "batch_size": 64,
+        "learning_rate": 1e-3,
+        "num_workers": 0,
+    }
+    generic_run(args=args, wandb_config=None)


### PR DESCRIPTION
## Summary
- implement `Poisson2DDataset` and its loss `Poisson2DPINNLoss`
- register dataset and loss in the factory and utility modules
- allow the trainer to treat 2D Poisson as a PINN dataset
- provide `tests/examples/pinn_poisson2d.py` example script

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 -c 'import dd4ml; print("ok")'`
- `python3 - <<'EOF'
from dd4ml.datasets.pinn_poisson2d import Poisson2DDataset
print(Poisson2DDataset.get_default_config().n_interior)
EOF` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68618e10e19883229bafbadfa70dc988