### PR TITLE
Add Poisson3D dataset and loss

### DIFF
--- a/src/dd4ml/datasets/pinn_poisson3d.py
+++ b/src/dd4ml/datasets/pinn_poisson3d.py
@@ -1,0 +1,56 @@
+import torch
+
+from .base_dataset import BaseDataset
+
+
+class Poisson3DDataset(BaseDataset):
+    """Dataset for 3D Poisson equation ``-\Delta u = f`` on [0,1]^3 with zero boundary conditions."""
+
+    @staticmethod
+    def get_default_config():
+        C = BaseDataset.get_default_config()
+        C.n_interior = 1000
+        C.n_boundary_side = 10
+        C.low = 0.0
+        C.high = 1.0
+        return C
+
+    def __init__(self, config, data=None, transform=None):
+        super().__init__(config, data, transform)
+        self._generate_points()
+
+    def _generate_points(self):
+        cfg = self.config
+        low, high = cfg.low, cfg.high
+        interior = torch.rand(cfg.n_interior, 3) * (high - low) + low
+        t = torch.linspace(low, high, cfg.n_boundary_side)
+
+        yy, zz = torch.meshgrid(t, t, indexing="ij")
+        yz = torch.stack([yy.reshape(-1), zz.reshape(-1)], dim=1)
+        left = torch.cat([torch.full((yz.size(0), 1), low), yz], dim=1)
+        right = torch.cat([torch.full((yz.size(0), 1), high), yz], dim=1)
+
+        xx, zz = torch.meshgrid(t, t, indexing="ij")
+        xz = torch.stack([xx.reshape(-1), zz.reshape(-1)], dim=1)
+        front = torch.cat([xz[:, 0:1], torch.full((xz.size(0), 1), low), xz[:, 1:2]], dim=1)
+        back = torch.cat([xz[:, 0:1], torch.full((xz.size(0), 1), high), xz[:, 1:2]], dim=1)
+
+        xx, yy = torch.meshgrid(t, t, indexing="ij")
+        xy = torch.stack([xx.reshape(-1), yy.reshape(-1)], dim=1)
+        bottom = torch.cat([xy, torch.full((xy.size(0), 1), low)], dim=1)
+        top = torch.cat([xy, torch.full((xy.size(0), 1), high)], dim=1)
+
+        boundary = torch.cat([left, right, front, back, bottom, top], dim=0)
+
+        self.x_interior = interior
+        self.x_boundary = boundary
+        self.data = torch.cat([interior, boundary], dim=0)
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        xyz = self.data[idx]
+        is_boundary = 1.0 if idx >= len(self.x_interior) else 0.0
+        return xyz, torch.tensor([is_boundary], dtype=torch.float32)
+

--- a/src/dd4ml/utility/__init__.py
+++ b/src/dd4ml/utility/__init__.py
@@ -11,3 +11,4 @@ from .utils import *
 from .wandb_utils import *
 from .pinn_poisson_loss import PoissonPINNLoss
 from .pinn_poisson2d_loss import Poisson2DPINNLoss
+from .pinn_poisson3d_loss import Poisson3DPINNLoss

--- a/src/dd4ml/utility/factory.py
+++ b/src/dd4ml/utility/factory.py
@@ -67,6 +67,7 @@ DATASET_MAP = {
     "tinyshakespeare": ("dd4ml.datasets.tinyshakespeare", "TinyShakespeareDataset"),
     "poisson1d": ("dd4ml.datasets.pinn_poisson", "Poisson1DDataset"),
     "poisson2d": ("dd4ml.datasets.pinn_poisson2d", "Poisson2DDataset"),
+    "poisson3d": ("dd4ml.datasets.pinn_poisson3d", "Poisson3DDataset"),
 }
 
 MODEL_MAP = {
@@ -101,6 +102,10 @@ CRITERION_MAP = {
     "pinn_poisson2d": (
         "dd4ml.utility.pinn_poisson2d_loss",
         "Poisson2DPINNLoss",
+    ),
+    "pinn_poisson3d": (
+        "dd4ml.utility.pinn_poisson3d_loss",
+        "Poisson3DPINNLoss",
     ),
 }
 

--- a/src/dd4ml/utility/pinn_poisson3d_loss.py
+++ b/src/dd4ml/utility/pinn_poisson3d_loss.py
@@ -1,0 +1,34 @@
+import math
+import torch
+import torch.nn as nn
+
+
+class Poisson3DPINNLoss(nn.Module):
+    """Loss for 3D Poisson PINN with forcing ``f(x,y,z)=3\pi^2\sin(\pi x)\sin(\pi y)\sin(\pi z)`` and zero Dirichlet boundary."""
+
+    def __init__(self, current_xyz=None):
+        super().__init__()
+        self.current_xyz = current_xyz
+
+    def forward(self, u_pred, boundary_flag):
+        if self.current_xyz is None:
+            raise ValueError("current_xyz must be set before calling Poisson3DPINNLoss")
+        xyz = self.current_xyz
+        xyz.requires_grad_(True)
+
+        grad_u = torch.autograd.grad(u_pred, xyz, torch.ones_like(u_pred), create_graph=True)[0]
+        u_x = grad_u[:, 0:1]
+        u_y = grad_u[:, 1:2]
+        u_z = grad_u[:, 2:3]
+
+        grad2_u_x = torch.autograd.grad(u_x, xyz, torch.ones_like(u_x), create_graph=True)[0][:, 0:1]
+        grad2_u_y = torch.autograd.grad(u_y, xyz, torch.ones_like(u_y), create_graph=True)[0][:, 1:2]
+        grad2_u_z = torch.autograd.grad(u_z, xyz, torch.ones_like(u_z), create_graph=True)[0][:, 2:3]
+
+        laplace_u = grad2_u_x + grad2_u_y + grad2_u_z
+
+        rhs = 3 * math.pi ** 2 * torch.sin(math.pi * xyz[:, 0:1]) * torch.sin(math.pi * xyz[:, 1:2]) * torch.sin(math.pi * xyz[:, 2:3])
+        interior = ((-laplace_u - rhs).squeeze()) ** 2 * (1 - boundary_flag.squeeze())
+        boundary = (u_pred.squeeze() ** 2) * boundary_flag.squeeze()
+        return interior.mean() + boundary.mean()
+

--- a/tests/examples/pinn_poisson3d.py
+++ b/tests/examples/pinn_poisson3d.py
@@ -1,0 +1,16 @@
+from dd4ml.utility import generic_run
+
+
+if __name__ == "__main__":
+    args = {
+        "dataset_name": "poisson3d",
+        "model_name": "pinn_ffnn",
+        "optimizer": "apts_d",
+        "criterion": "pinn_poisson3d",
+        "epochs": 1000,
+        "batch_size": 64,
+        "learning_rate": 1e-3,
+        "num_workers": 0,
+    }
+    generic_run(args=args, wandb_config=None)
+

--- a/tests/run_config_file.py
+++ b/tests/run_config_file.py
@@ -20,6 +20,7 @@ from dd4ml.utility import (
 
 from dd4ml.datasets.pinn_poisson import Poisson1DDataset
 from dd4ml.datasets.pinn_poisson2d import Poisson2DDataset
+from dd4ml.datasets.pinn_poisson3d import Poisson3DDataset
 
 try:
     import wandb
@@ -218,7 +219,7 @@ def main(
             delta = trainer.optimizer.delta
             thing_to_print = "delta"
         
-        if isinstance(trainer.train_dataset, Poisson1DDataset) or isinstance(trainer.train_dataset, Poisson2DDataset):
+        if isinstance(trainer.train_dataset, (Poisson1DDataset, Poisson2DDataset, Poisson3DDataset)):
             dprint(
                 f"Epoch {trainer.epoch_num}, g-evals: {trainer.grad_evals}, loss: {trainer.loss:.4e}, accuracy: {trainer.accuracy:.2f}%, time: {trainer.epoch_dt * 1000:.2f}ms, running time: {trainer.running_time:.2f}s, {thing_to_print}: {delta:.6e}"
             )


### PR DESCRIPTION
## Summary
- support a harder 3D Poisson PINN problem
- map Poisson3D dataset and criterion in factory
- expose new loss in utility package
- example run script
- update helper script for new dataset

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6861b46341308322b70c18714c0c73d9