### PR TITLE
Add DeepONet architecture and dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,12 @@ The src folder is structured as follows:
 - pmw
 - utility
 
-You can extend the library by adding your own files in any of these modules. If you create a new folder within them, make sure to add an ```__init__.py``` file and then re-run ```python3 -m pip install .```, or ```python3 -m pip install --force-reinstall .``` if necessary. 
+You can extend the library by adding your own files in any of these modules. If you create a new folder within them, make sure to add an ```__init__.py``` file and then re-run ```python3 -m pip install .```, or ```python3 -m pip install --force-reinstall .``` if necessary.
+
+### DeepONet Example
+This project includes a basic DeepONet implementation (`deeponet`) together with
+a small synthetic dataset (`deeponet_sine`). To try it out, run
+`tests/run_config_file.py` with `--model_name deeponet --dataset_name deeponet_sine`.
 
 ## Note
 In case it's necessary, you may need to run the following:

--- a/src/dd4ml/datasets/__init__.py
+++ b/src/dd4ml/datasets/__init__.py
@@ -1,0 +1,1 @@
+from .deeponet_sine import SineOperatorDataset

--- a/src/dd4ml/datasets/deeponet_sine.py
+++ b/src/dd4ml/datasets/deeponet_sine.py
@@ -1,0 +1,41 @@
+import math
+import torch
+from .base_dataset import BaseDataset
+
+class SineOperatorDataset(BaseDataset):
+    """Synthetic dataset for training DeepONet on functions a -> sin(a * x)."""
+
+    @staticmethod
+    def get_default_config():
+        C = BaseDataset.get_default_config()
+        C.n_samples = 1000
+        C.n_sensors = 50
+        C.n_trunk = 100
+        C.low = 0.0
+        C.high = math.pi * 2
+        return C
+
+    def __init__(self, config, data=None, transform=None):
+        super().__init__(config, data, transform)
+        self._generate_data()
+
+    def _generate_data(self):
+        cfg = self.config
+        # Sensor and trunk locations are fixed across samples
+        self.sensors = torch.linspace(cfg.low, cfg.high, cfg.n_sensors)
+        self.trunk_points = torch.linspace(cfg.low, cfg.high, cfg.n_trunk)
+        # Sample random parameters a for each function
+        self.a_vals = torch.rand(cfg.n_samples) * (cfg.high - cfg.low) / cfg.high
+        self.branch_data = torch.sin(self.a_vals.unsqueeze(1) * self.sensors)
+
+    def __len__(self):
+        return self.config.n_samples * self.config.n_trunk
+
+    def __getitem__(self, idx):
+        sample_idx = idx // self.config.n_trunk
+        trunk_idx = idx % self.config.n_trunk
+        a = self.a_vals[sample_idx]
+        branch = self.branch_data[sample_idx]
+        x = self.trunk_points[trunk_idx]
+        y = torch.sin(a * x)
+        return (branch, x.unsqueeze(0)), y.unsqueeze(0)

--- a/src/dd4ml/models/deeponet/__init__.py
+++ b/src/dd4ml/models/deeponet/__init__.py
@@ -1,0 +1,1 @@
+from .deeponet import DeepONet

--- a/src/dd4ml/models/deeponet/deeponet.py
+++ b/src/dd4ml/models/deeponet/deeponet.py
@@ -1,0 +1,41 @@
+import torch
+import torch.nn as nn
+from dd4ml.models.base_model import BaseModel
+
+class DeepONet(BaseModel):
+    """Minimal DeepONet implementation with branch and trunk networks."""
+
+    @staticmethod
+    def get_default_config():
+        C = BaseModel.get_default_config()
+        C.branch_hidden = [64, 64]
+        C.trunk_hidden = [64, 64]
+        C.branch_input_dim = None
+        C.trunk_input_dim = 1
+        C.output_dim = 1
+        return C
+
+    def __init__(self, config):
+        super().__init__(config)
+        assert config.branch_input_dim is not None, "branch_input_dim must be set"
+
+        self.branch_net = self._make_mlp(config.branch_input_dim, config.branch_hidden)
+        self.trunk_net = self._make_mlp(config.trunk_input_dim, config.trunk_hidden)
+        p = config.branch_hidden[-1]
+        assert config.trunk_hidden[-1] == p, "branch and trunk output dims must match"
+        self.p = p
+
+    def _make_mlp(self, in_dim, hidden):
+        layers = []
+        for h in hidden:
+            layers.append(nn.Linear(in_dim, h))
+            layers.append(nn.ReLU())
+            in_dim = h
+        return nn.Sequential(*layers)
+
+    def forward(self, inputs):
+        branch, trunk = inputs
+        b = self.branch_net(branch)
+        t = self.trunk_net(trunk)
+        y = (b * t).sum(dim=1, keepdim=True)
+        return y

--- a/src/dd4ml/utility/factory.py
+++ b/src/dd4ml/utility/factory.py
@@ -68,6 +68,7 @@ DATASET_MAP = {
     "poisson1d": ("dd4ml.datasets.pinn_poisson", "Poisson1DDataset"),
     "poisson2d": ("dd4ml.datasets.pinn_poisson2d", "Poisson2DDataset"),
     "poisson3d": ("dd4ml.datasets.pinn_poisson3d", "Poisson3DDataset"),
+    "deeponet_sine": ("dd4ml.datasets.deeponet_sine", "SineOperatorDataset"),
 }
 
 MODEL_MAP = {
@@ -80,6 +81,7 @@ MODEL_MAP = {
     "microgpt": ("dd4ml.models.gpt.nanogpt.model", "GPT"),
     "gpt2": ("dd4ml.models.gpt.nanogpt.model", "GPT"),
     "pinn_ffnn": ("dd4ml.models.ffnn.pinn_ffnn", "PINNFFNN"),
+    "deeponet": ("dd4ml.models.deeponet.deeponet", "DeepONet"),
 }
 
 CRITERION_MAP = {


### PR DESCRIPTION
## Summary
- add a synthetic sine-operator dataset for DeepONet
- implement a minimal DeepONet model
- register new dataset and model in the Factory
- update Trainer to support tuple inputs via `_move_to_device`
- document usage of the new components in README

## Testing
- `python3 -m py_compile src/dd4ml/datasets/deeponet_sine.py src/dd4ml/models/deeponet/deeponet.py src/dd4ml/trainer.py`
- ❌ `pip install torch torchvision --break-system-packages --no-cache-dir` (failed to complete)


------
https://chatgpt.com/codex/tasks/task_e_68629a4e9f94832280cfbc8909f4123b