### PR TITLE
Fix DeepONetMSELoss instantiation

### DIFF
--- a/src/dd4ml/utility/factory.py
+++ b/src/dd4ml/utility/factory.py
@@ -1,5 +1,6 @@
 from .ml_utils import cross_entropy_transformers
 from .utils import import_attr
+from .deeponet_loss import DeepONetMSELoss
 
 
 class Factory:
@@ -110,8 +111,8 @@ CRITERION_MAP = {
         "Poisson3DPINNLoss",
     ),
     "deeponet_mse": (
-        "dd4ml.utility.deeponet_loss",
-        "DeepONetMSELoss",
+        "",
+        lambda ds=None: DeepONetMSELoss(),
     ),
 }
 


### PR DESCRIPTION
## Summary
- ensure the DeepONet MSE loss is instantiated without passing dataset
- import DeepONetMSELoss in the factory

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6862a5f4d1308322a0af6bd6694ea9b6