### PR TITLE
Fix dataset length for pipeline middle ranks

### DIFF
--- a/src/dd4ml/dataloaders.py
+++ b/src/dd4ml/dataloaders.py
@@ -318,14 +318,14 @@ class GeneralizedDistributedDataLoader(DataLoader):
                 )
         # rank in the middle does not require any real data
         elif rank not in first_layer_ranks + last_layer_ranks:
-            # Make a mock dataset with the same amount of batches as the original dataset (this is needed to keep iterations consistent across all ranks)
-            amount_of_batches = (
-                1 if len(dataset) == batch_size else len(dataset) // batch_size
-            )
-            dataset = MockDataset(dataset, amount_of_batches, device=device, first=None)
+            # Intermediate ranks operate on mock data, but must iterate the
+            # same number of times as the first/last stages.  Use a mock
+            # dataset with the **full** length and the per-replica batch size
+            # so that bs matches across all ranks.
+            dataset = MockDataset(dataset, len(dataset), device=device, first=None)
             super(GeneralizedDistributedDataLoader, self).__init__(
                 dataset=dataset,
-                batch_size=1,
+                batch_size=batch_size // tot_replicas,
                 shuffle=False,
                 num_workers=num_workers,
                 pin_memory=pin_memory,


### PR DESCRIPTION
## Summary
- align mock datasets on intermediate pipeline stages with real dataset size
- use same per-replica batch size to keep iteration counts equal across ranks

## Testing
- `pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_6881dd24a2908322a90dcd0ee1471375