### PR TITLE
Handle Sequential modules in ShardedLayer

### DIFF
--- a/src/dd4ml/pmw/sharded_layer.py
+++ b/src/dd4ml/pmw/sharded_layer.py
@@ -33,11 +33,19 @@ class ShardedLayer(BasePMWModel):
                 else:
                     # Single-rank trainable module
                     try:
-                        self.layer = obj(**layer_dict["callable"]["settings"]).to(
-                            self.tensor_device
-                        )
-                    except:
+                        if obj is nn.Sequential and "modules" in layer_dict["callable"]["settings"]:
+                            mods = [
+                                m["object"](**m.get("settings", {}))
+                                for m in layer_dict["callable"]["settings"]["modules"]
+                            ]
+                            self.layer = obj(*mods).to(self.tensor_device)
+                        else:
+                            self.layer = obj(**layer_dict["callable"]["settings"]).to(
+                                self.tensor_device
+                            )
+                    except Exception as e:
                         print("asd")
+                        raise e
 
                     # Optional initialization
                     if isinstance(self.layer, nn.Linear):


### PR DESCRIPTION
## Summary
- build sequential layers from provided module specs in `ShardedLayer`
- raise the underlying exception when layer creation fails

## Testing
- `python -m py_compile src/dd4ml/pmw/sharded_layer.py`

------
https://chatgpt.com/codex/tasks/task_e_6883569d1b6c8322a2989fed6059c3b7