### PR TITLE
Add Allen-Cahn dataset and loss for PINN

### DIFF
--- a/src/dd4ml/datasets/pinn_allencahn.py
+++ b/src/dd4ml/datasets/pinn_allencahn.py
@@ -1,0 +1,35 @@
+import torch
+
+from .base_dataset import BaseDataset
+
+class AllenCahn1DDataset(BaseDataset):
+    """Dataset for 1D Allen-Cahn equation on [0,1] with u(0)=1 and u(1)=-1."""
+
+    @staticmethod
+    def get_default_config():
+        C = BaseDataset.get_default_config()
+        C.n_interior = 100
+        C.n_boundary = 2
+        C.low = 0.0
+        C.high = 1.0
+        return C
+
+    def __init__(self, config, data=None, transform=None):
+        super().__init__(config, data, transform)
+        self._generate_points()
+
+    def _generate_points(self):
+        cfg = self.config
+        interior = torch.linspace(cfg.low, cfg.high, cfg.n_interior, dtype=torch.float32).unsqueeze(1)
+        boundary = torch.tensor([[cfg.low], [cfg.high]], dtype=torch.float32)
+        self.x_interior = interior
+        self.x_boundary = boundary
+        self.data = torch.cat([interior, boundary], dim=0)
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        x = self.data[idx]
+        is_boundary = 1.0 if idx >= len(self.x_interior) else 0.0
+        return x, torch.tensor([is_boundary], dtype=torch.float32)

--- a/src/dd4ml/trainer.py
+++ b/src/dd4ml/trainer.py
@@ -20,6 +20,7 @@ from dd4ml.pmw.weight_parallelized_tensor import WeightParallelizedTensor
 from dd4ml.datasets.pinn_poisson import Poisson1DDataset
 from dd4ml.datasets.pinn_poisson2d import Poisson2DDataset
 from dd4ml.datasets.pinn_poisson3d import Poisson3DDataset
+from dd4ml.datasets.pinn_allencahn import AllenCahn1DDataset
 from dd4ml.datasets.deeponet_sine import SineOperatorDataset
 from dd4ml.utility import CfgNode as CN
 from dd4ml.utility import closure, dprint
@@ -394,6 +395,7 @@ class Trainer:
                 Poisson1DDataset,
                 Poisson2DDataset,
                 Poisson3DDataset,
+                AllenCahn1DDataset,
             ),
         ):
             self.run_by_epoch_PINN()
@@ -418,6 +420,7 @@ class Trainer:
                 Poisson1DDataset,
                 Poisson2DDataset,
                 Poisson3DDataset,
+                AllenCahn1DDataset,
             ),
         )
         context = torch.enable_grad if requires_grad_eval else torch.no_grad
@@ -496,7 +499,13 @@ class Trainer:
         """Compute test accuracy across all processes (and pipeline stages)."""
         if isinstance(
             self.test_dataset,
-            (Poisson1DDataset, Poisson2DDataset, Poisson3DDataset, SineOperatorDataset),
+            (
+                Poisson1DDataset,
+                Poisson2DDataset,
+                Poisson3DDataset,
+                AllenCahn1DDataset,
+                SineOperatorDataset,
+            ),
         ):
             self.accuracy = float("nan")
             return
@@ -602,7 +611,10 @@ class Trainer:
         bs = y.size(0)
 
         # Special handling for PINN datasets
-        if isinstance(self.train_dataset, (Poisson1DDataset, Poisson2DDataset, Poisson3DDataset)):
+        if isinstance(
+            self.train_dataset,
+            (Poisson1DDataset, Poisson2DDataset, Poisson3DDataset, AllenCahn1DDataset),
+        ):
             return self._train_one_batch_PINN(x, y, first_grad)
 
         # optional control batch for ASNTR

--- a/src/dd4ml/utility/__init__.py
+++ b/src/dd4ml/utility/__init__.py
@@ -12,3 +12,4 @@ from .wandb_utils import *
 from .pinn_poisson_loss import PoissonPINNLoss
 from .pinn_poisson2d_loss import Poisson2DPINNLoss
 from .pinn_poisson3d_loss import Poisson3DPINNLoss
+from .pinn_allencahn_loss import AllenCahnPINNLoss

--- a/src/dd4ml/utility/factory.py
+++ b/src/dd4ml/utility/factory.py
@@ -69,6 +69,7 @@ DATASET_MAP = {
     "poisson1d": ("dd4ml.datasets.pinn_poisson", "Poisson1DDataset"),
     "poisson2d": ("dd4ml.datasets.pinn_poisson2d", "Poisson2DDataset"),
     "poisson3d": ("dd4ml.datasets.pinn_poisson3d", "Poisson3DDataset"),
+    "allencahn1d": ("dd4ml.datasets.pinn_allencahn", "AllenCahn1DDataset"),
     "deeponet_sine": ("dd4ml.datasets.deeponet_sine", "SineOperatorDataset"),
 }
 
@@ -112,6 +113,10 @@ CRITERION_MAP = {
     "pinn_poisson3d": (
         "dd4ml.utility.pinn_poisson3d_loss",
         "Poisson3DPINNLoss",
+    ),
+    "pinn_allencahn": (
+        "dd4ml.utility.pinn_allencahn_loss",
+        "AllenCahnPINNLoss",
     ),
     "deeponet_mse": (
         "",

--- a/src/dd4ml/utility/pinn_allencahn_loss.py
+++ b/src/dd4ml/utility/pinn_allencahn_loss.py
@@ -1,0 +1,31 @@
+import torch
+import torch.nn as nn
+
+class AllenCahnPINNLoss(nn.Module):
+    """Loss for 1D Allen-Cahn PINN (-u'' + u^3 - u = 0, u(0)=1, u(1)=-1)."""
+
+    def __init__(self, current_x=None, low=0.0, high=1.0):
+        super().__init__()
+        self.current_x = current_x
+        self.low = low
+        self.high = high
+
+    def forward(self, u_pred, boundary_flag):
+        if self.current_x is None:
+            raise ValueError("current_x must be set before calling AllenCahnPINNLoss")
+        x = self.current_x
+        x.requires_grad_(True)
+
+        grad_u = torch.autograd.grad(u_pred, x, torch.ones_like(u_pred), create_graph=True)[0]
+        grad2_u = torch.autograd.grad(grad_u, x, torch.ones_like(grad_u), create_graph=True)[0]
+
+        residual = -grad2_u + u_pred ** 3 - u_pred
+        interior = (residual.squeeze() ** 2) * (1 - boundary_flag.squeeze())
+
+        bc_val = torch.where(
+            torch.isclose(x.squeeze(), torch.tensor(self.low, device=x.device)),
+            torch.tensor(1.0, device=x.device),
+            torch.tensor(-1.0, device=x.device),
+        )
+        boundary = ((u_pred.squeeze() - bc_val) ** 2) * boundary_flag.squeeze()
+        return interior.mean() + boundary.mean()

--- a/src/dd4ml/utility/trainer_setup.py
+++ b/src/dd4ml/utility/trainer_setup.py
@@ -41,6 +41,7 @@ def get_config_model_and_trainer(args, wandb_config):
     from dd4ml.datasets.pinn_poisson import Poisson1DDataset
     from dd4ml.datasets.pinn_poisson2d import Poisson2DDataset
     from dd4ml.datasets.pinn_poisson3d import Poisson3DDataset
+    from dd4ml.datasets.pinn_allencahn import AllenCahn1DDataset
     from dd4ml.pmw.model_handler import ModelHandler
     from dd4ml.pmw.parallelized_model import ParallelizedModel
     from dd4ml.trainer import Trainer
@@ -97,7 +98,10 @@ def get_config_model_and_trainer(args, wandb_config):
     if (
         hasattr(all_config.model, "input_features")
         and all_config.model.input_features is not None
-        and isinstance(dataset, (Poisson1DDataset, Poisson2DDataset, Poisson3DDataset))
+        and isinstance(
+            dataset,
+            (Poisson1DDataset, Poisson2DDataset, Poisson3DDataset, AllenCahn1DDataset),
+        )
     ):
         sample_x, _ = dataset[0]
         all_config.model.input_features = sample_x.numel()

--- a/tests/run_config_file.py
+++ b/tests/run_config_file.py
@@ -10,6 +10,7 @@ import yaml
 from dd4ml.datasets.pinn_poisson import Poisson1DDataset
 from dd4ml.datasets.pinn_poisson2d import Poisson2DDataset
 from dd4ml.datasets.pinn_poisson3d import Poisson3DDataset
+from dd4ml.datasets.pinn_allencahn import AllenCahn1DDataset
 from dd4ml.utility import (
     broadcast_dict,
     detect_environment,
@@ -220,7 +221,7 @@ def main(
 
         if isinstance(
             trainer.train_dataset,
-            (Poisson1DDataset, Poisson2DDataset, Poisson3DDataset),
+            (Poisson1DDataset, Poisson2DDataset, Poisson3DDataset, AllenCahn1DDataset),
         ):
             dprint(
                 f"Epoch {trainer.epoch_num}, g-evals: {trainer.grad_evals}, loss: {trainer.loss:.4e}, accuracy: {trainer.accuracy:.2f}%, time: {trainer.epoch_dt * 1000:.2f}ms, running time: {trainer.running_time:.2f}s, {thing_to_print}: {delta:.6e}"


### PR DESCRIPTION
## Summary
- implement `AllenCahn1DDataset` and `AllenCahnPINNLoss`
- register dataset and criterion in factory
- expose `AllenCahnPINNLoss` in utility package
- integrate dataset with trainer utilities and test harness

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_688cbbdf9dc08322a24d3a57addd5149