### PR TITLE
Add PINN domain-splitting APTS variant

### DIFF
--- a/src/dd4ml/datasets/pinn_allencahn.py
+++ b/src/dd4ml/datasets/pinn_allencahn.py
@@ -33,3 +33,43 @@ class AllenCahn1DDataset(BaseDataset):
         x = self.data[idx]
         is_boundary = 1.0 if idx >= len(self.x_interior) else 0.0
         return x, torch.tensor([is_boundary], dtype=torch.float32)
+
+    # ------------------------------------------------------------------
+    # Domain decomposition utilities
+    # ------------------------------------------------------------------
+    def split_domain(self, num_subdomains: int):
+        """Split the 1D domain into ``num_subdomains`` contiguous pieces.
+
+        Returns a list of ``AllenCahn1DDataset`` objects, each restricted to
+        a sub-interval of ``[low, high]``.  The number of interior points is
+        distributed roughly evenly across subdomains while boundary points are
+        kept at the global domain boundaries.
+        """
+
+        if num_subdomains < 1:
+            raise ValueError("num_subdomains must be a positive integer")
+
+        import copy
+
+        cfg = self.config
+        subdatasets = []
+        step = (cfg.high - cfg.low) / num_subdomains
+
+        for i in range(num_subdomains):
+            sub_cfg = copy.deepcopy(cfg)
+            sub_cfg.low = cfg.low + i * step
+            sub_cfg.high = cfg.low + (i + 1) * step
+
+            # Evenly distribute interior points; keep one boundary point at each
+            # end of the global domain. Only the first and last subdomain
+            # include the respective global boundary point.
+            sub_cfg.n_interior = int(round(cfg.n_interior / num_subdomains))
+            sub_cfg.n_boundary = 0
+            if i == 0:
+                sub_cfg.n_boundary += 1
+            if i == num_subdomains - 1:
+                sub_cfg.n_boundary += 1
+
+            subdatasets.append(AllenCahn1DDataset(sub_cfg))
+
+        return subdatasets

--- a/src/dd4ml/optimizers/apts_pinn.py
+++ b/src/dd4ml/optimizers/apts_pinn.py
@@ -1,0 +1,66 @@
+from .apts_d import APTS_D
+import torch
+from torch.nn.utils import vector_to_parameters
+
+class APTS_PINN(APTS_D):
+    __name__ = "APTS_PINN"
+
+    def __init__(self, *args, num_subdomains=1, criterion=None, **kwargs):
+        super().__init__(*args, criterion=criterion, **kwargs)
+        self.num_subdomains = int(max(1, num_subdomains))
+        low = getattr(self.criterion, "low", 0.0)
+        high = getattr(self.criterion, "high", 1.0)
+        self.subdomain_bounds = torch.linspace(low, high, self.num_subdomains + 1)
+
+    def step(self, inputs, labels, inputs_d=None, labels_d=None, hNk=None):
+        self.inputs = inputs.clone().detach().requires_grad_(True)
+        self.labels = labels
+        self.inputs_d, self.labels_d = inputs_d, labels_d
+        self.hNk = hNk
+
+        # Global initial loss/grad for the entire domain
+        self.grad_evals, self.loc_grad_evals = 0.0, 0.0
+        self.init_glob_flat = self.glob_params_to_vector()
+        self.criterion.current_x = self.inputs
+        self.init_glob_loss = self.glob_closure_main(compute_grad=True)
+        init_glob_grad_full = self.glob_grad_to_vector()
+        full_inputs = self.inputs
+        full_labels = labels
+
+        total_step = torch.zeros_like(self.init_glob_flat)
+        total_red = torch.zeros(1, device=self.init_glob_flat.device)
+
+        x_vals = inputs.squeeze()
+        for i in range(self.num_subdomains):
+            low, high = self.subdomain_bounds[i], self.subdomain_bounds[i + 1]
+            mask = (x_vals >= low) & (x_vals <= high)
+            if mask.sum() == 0:
+                continue
+            self.inputs = full_inputs[mask].clone().detach().requires_grad_(True)
+            self.labels = labels[mask]
+            self.criterion.current_x = self.inputs
+            glob_loss = self.glob_closure_main(compute_grad=True)
+            glob_grad = self.glob_grad_to_vector()
+            init_loc_loss = self.loc_closure(compute_grad=True)
+            init_loc_grad = self.loc_grad_to_vector()
+            if self.foc:
+                self.resid = glob_grad - init_loc_grad
+            loc_loss, _ = self.loc_steps(init_loc_loss, init_loc_grad)
+            with torch.no_grad():
+                step = self.loc_params_to_vector() - self.init_glob_flat
+                loc_red = init_loc_loss - loc_loss
+            total_step += step
+            total_red += loc_red
+            vector_to_parameters(self.init_glob_flat, self.model.parameters())
+            vector_to_parameters(self.init_glob_flat, self.loc_model.parameters())
+
+        self.inputs, self.labels = full_inputs, full_labels
+        self.criterion.current_x = full_inputs
+        self.init_glob_grad = init_glob_grad_full
+
+        step, pred = self.aggregate_loc_steps_and_losses(total_step, total_red)
+        loss, grad, self.glob_opt.delta = self.control_step(step, pred)
+        if self.glob_pass:
+            loss, grad = self.glob_steps(loss, grad)
+        self.sync_glob_to_loc()
+        return loss

--- a/src/dd4ml/trainer.py
+++ b/src/dd4ml/trainer.py
@@ -683,7 +683,7 @@ class Trainer:
                 }
             elif any(
                 k in self.optimizer.__class__.__name__.lower()
-                for k in ("apts_d", "apts_p")
+                for k in ("apts_d", "apts_p", "apts_pinn")
             ):
                 step_args = {
                     "inputs": x,
@@ -785,7 +785,8 @@ class Trainer:
                 "final_subdomain_closure": final_subdomain_closure,
             }
         elif any(
-            k in self.optimizer.__class__.__name__.lower() for k in ("apts_d", "apts_p")
+            k in self.optimizer.__class__.__name__.lower()
+            for k in ("apts_d", "apts_p", "apts_pinn")
         ):
             step_args = {
                 "inputs": x,

--- a/src/dd4ml/utility/trainer_setup.py
+++ b/src/dd4ml/utility/trainer_setup.py
@@ -272,6 +272,32 @@ def get_config_model_and_trainer(args, wandb_config):
             tol=all_config.trainer.tol,
             **all_config.trainer.apts_params,
         )
+    elif optimizer_name == "apts_pinn":
+        from dd4ml.optimizers.apts_pinn import APTS_PINN
+
+        all_config.trainer.norm_type = parse_norm(all_config.trainer.norm_type)
+
+        all_config.trainer = APTS_PINN.setup_APTS_hparams(all_config.trainer)
+
+        optimizer_obj = APTS_PINN(
+            params=model.parameters(),
+            model=model,
+            criterion=criterion,
+            device=get_device(),
+            nr_models=all_config.model.num_subdomains,
+            glob_opt=all_config.trainer.glob_opt,
+            glob_opt_hparams=all_config.trainer.glob_opt_hparams,
+            loc_opt=all_config.trainer.loc_opt,
+            loc_opt_hparams=all_config.trainer.loc_opt_hparams,
+            glob_pass=all_config.trainer.glob_pass,
+            foc=all_config.trainer.foc,
+            norm_type=all_config.trainer.norm_type,
+            max_loc_iters=all_config.trainer.max_loc_iters,
+            max_glob_iters=all_config.trainer.max_glob_iters,
+            tol=all_config.trainer.tol,
+            num_subdomains=all_config.trainer.num_subdomains,
+            **all_config.trainer.apts_params,
+        )
     elif optimizer_name == "lssr1_tr":
         from dd4ml.optimizers.lssr1_tr import LSSR1_TR
 

--- a/tests/test_pinn_subdomains.py
+++ b/tests/test_pinn_subdomains.py
@@ -1,0 +1,63 @@
+import torch
+from dd4ml.datasets.pinn_allencahn import AllenCahn1DDataset
+from dd4ml.models.ffnn.pinn_ffnn import PINNFFNN
+from dd4ml.optimizers.apts_pinn import APTS_PINN
+from dd4ml.optimizers.tr import TR
+from dd4ml.utility.pinn_allencahn_loss import AllenCahnPINNLoss
+
+
+def test_split_domain():
+    cfg = AllenCahn1DDataset.get_default_config()
+    ds = AllenCahn1DDataset(cfg)
+    subs = ds.split_domain(2)
+    assert len(subs) == 2
+    # first subdomain should start at global low, last at global high
+    assert torch.isclose(subs[0].x_boundary[0], torch.tensor([cfg.low]))
+    assert torch.isclose(subs[-1].x_boundary[-1], torch.tensor([cfg.high]))
+
+
+def test_apts_pinn_step_runs():
+    cfg = AllenCahn1DDataset.get_default_config()
+    ds = AllenCahn1DDataset(cfg)
+    model_cfg = PINNFFNN.get_default_config()
+    model = PINNFFNN(model_cfg)
+    criterion = AllenCahnPINNLoss()
+
+    tr_kwargs = dict(
+        delta=0.1,
+        nu_dec=0.25,
+        nu_inc=0.75,
+        inc_factor=1.2,
+        dec_factor=0.9,
+        max_delta=2.0,
+        min_delta=1e-3,
+        tol=1e-6,
+    )
+
+    opt = APTS_PINN(
+        model.parameters(),
+        model=model,
+        criterion=criterion,
+        device="cpu",
+        nr_models=1,
+        glob_opt=TR,
+        glob_opt_hparams=tr_kwargs,
+        loc_opt=TR,
+        loc_opt_hparams=tr_kwargs,
+        glob_pass=False,
+        foc=False,
+        norm_type=2,
+        max_loc_iters=1,
+        max_glob_iters=1,
+        num_subdomains=2,
+        **tr_kwargs,
+    )
+
+    x = ds.data
+    boundary_flag = torch.cat([
+        torch.zeros(len(ds.x_interior), 1),
+        torch.ones(len(ds.x_boundary), 1),
+    ])
+    criterion.current_x = x
+    loss = opt.step(inputs=x, labels=boundary_flag)
+    assert torch.isfinite(loss)


### PR DESCRIPTION
## Summary
- extend Allen Cahn 1D dataset with `split_domain` helper for subdomain generation
- implement `APTS_PINN` optimizer that runs TR on each subdomain and aggregates the steps
- wire new optimizer into trainer and setup so PINNs can use domain-splitting APTS

## Testing
- `pytest tests/test_pinn_subdomains.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6891b5f69b5c8322a14acdd94a5a114b