### PR TITLE
Ensure boundary samples available on all ranks

### DIFF
--- a/src/dd4ml/trainer.py
+++ b/src/dd4ml/trainer.py
@@ -185,11 +185,12 @@ class Trainer:
                     f"Per-process batch size {pp_bs} < 1; increase global batch size."
                 )
 
+            shuffle_flag = not isinstance(ds_train, AllenCahn1DDataset)
             base_train = DistributedSampler(
                 ds_train,
                 num_replicas=world_size,
                 rank=rank,
-                shuffle=True,
+                shuffle=shuffle_flag,
                 drop_last=self._apts_ip_present(),
             )
             train_ov = OverlapBatchSampler(


### PR DESCRIPTION
## Summary
- replicate Allen-Cahn boundary points for every process and keep a boundary mask
- skip shuffling when using Allen-Cahn dataset so each rank sees boundary samples

## Testing
- `pytest -q`
- `python /tmp/run_ac.py`


------
https://chatgpt.com/codex/tasks/task_e_6891b8b365848322afc565c422ba9f9a