### PR TITLE
Fix PINN loss selection and grad-eval tracking

### DIFF
--- a/tests/submit_jobs_allencahn1d.sh
+++ b/tests/submit_jobs_allencahn1d.sh
@@ -61,7 +61,8 @@ APTS_LOC_OPTS=(tr)  # options: tr, lssr1_tr, sgd, adam, etc.; for APTS_IP, only 
 FOC_OPTS=(false)
 
 # Evaluation parameters: epochs, max iterations, loss
-EVAL_PARAMS=(epochs=10 max_iters=0 criterion=cross_entropy)
+# Use Allen-Cahn specific PINN loss instead of a classification loss.
+EVAL_PARAMS=(epochs=10 max_iters=0 criterion=pinn_allencahn)
 
 # Adaptive solver parameters (base)
 APTS_PARAMS=(batch_inc_factor=1.5 overlap=0.33 glob_second_order=false)


### PR DESCRIPTION
## Summary
- Use Allen-Cahn specific PINN loss in `submit_jobs_allencahn1d.sh` instead of cross-entropy which produced zero loss.
- Track gradient evaluations in `_train_one_batch_PINN` with APTS-IP aware scaling so epoch statistics are correct.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_6891c67fbbb88322911a9d2e5b598e88