### PR TITLE
Add subdomain-aware APTS-PINN and register in trainer setup

### DIFF
--- a/src/dd4ml/optimizers/apts_pinn.py
+++ b/src/dd4ml/optimizers/apts_pinn.py
@@ -26,21 +26,64 @@ class APTS_PINN(APTS_D):
         low, high = self.subdomain_bounds[idx], self.subdomain_bounds[idx + 1]
         mask = (x >= low) & (x <= high)
 
-        # Extract subdomain data for local optimisation
-        in_sub = inputs[mask].detach().requires_grad_(True)
-        lab_sub = labels[mask] if labels is not None else None
-        in_d_sub = (
-            inputs_d[mask].detach().requires_grad_(True)
+        # Create tensors for full domain (for global pass) and subdomain (for local pass)
+        full_in = inputs.detach().requires_grad_(True)
+        full_lab = labels
+        full_in_d = (
+            inputs_d.detach().requires_grad_(True)
             if inputs_d is not None
             else None
         )
-        lab_d_sub = labels_d[mask] if labels_d is not None else None
+        full_lab_d = labels_d
 
-        # Tell the criterion which x‐values it sees
-        self.criterion.current_x = in_sub
+        sub_in = full_in[mask]
+        sub_lab = full_lab[mask] if full_lab is not None else None
+        sub_in_d = full_in_d[mask] if full_in_d is not None else None
+        sub_lab_d = full_lab_d[mask] if full_lab_d is not None else None
 
-        # Run the APTS_D step: local pass sees only subdomain,
-        # global pass inside super().step still uses full inputs
-        return super().step(
-            in_sub, lab_sub, inputs_d=in_d_sub, labels_d=lab_d_sub, hNk=hNk
-        )
+        # ------------------------------------------------------------------
+        # Global: evaluate loss/grad on full domain
+        # ------------------------------------------------------------------
+        self.inputs, self.labels = full_in, full_lab
+        self.inputs_d, self.labels_d = full_in_d, full_lab_d
+        self.hNk = hNk
+        self.grad_evals, self.loc_grad_evals = 0.0, 0.0
+        self.init_glob_flat = self.glob_params_to_vector()
+        self.criterion.current_x = full_in
+        self.init_glob_loss = self.glob_closure_main(compute_grad=True)
+        self.init_glob_grad = self.glob_grad_to_vector()
+
+        # ------------------------------------------------------------------
+        # Local: restrict to subdomain for local optimisation
+        # ------------------------------------------------------------------
+        self.inputs, self.labels = sub_in, sub_lab
+        self.inputs_d, self.labels_d = sub_in_d, sub_lab_d
+        self.criterion.current_x = sub_in
+        self.init_loc_loss = self.loc_closure(compute_grad=True)
+        self.init_loc_grad = self.loc_grad_to_vector()
+
+        if self.foc:
+            self.resid = self.init_glob_grad - self.init_loc_grad
+
+        loc_loss, _ = self.loc_steps(self.init_loc_loss, self.init_loc_grad)
+
+        with torch.no_grad():
+            step = self.loc_params_to_vector() - self.init_glob_flat
+            loc_red = self.init_loc_loss - loc_loss
+        step, pred = self.aggregate_loc_steps_and_losses(step, loc_red)
+
+        # ------------------------------------------------------------------
+        # Global acceptance and optional global steps on full domain
+        # ------------------------------------------------------------------
+        self.inputs, self.labels = full_in, full_lab
+        self.inputs_d, self.labels_d = full_in_d, full_lab_d
+        self.criterion.current_x = full_in
+
+        loss, grad, self.glob_opt.delta = self.control_step(step, pred)
+
+        if self.glob_pass:
+            loss, grad = self.glob_steps(loss, grad)
+
+        # Synchronize global and local models for next iteration
+        self.sync_glob_to_loc()
+        return loss

--- a/src/dd4ml/utility/trainer_setup.py
+++ b/src/dd4ml/utility/trainer_setup.py
@@ -278,6 +278,8 @@ def get_config_model_and_trainer(args, wandb_config):
         all_config.trainer.norm_type = parse_norm(all_config.trainer.norm_type)
 
         all_config.trainer = APTS_PINN.setup_APTS_hparams(all_config.trainer)
+        # Mark as APTS variant so downstream utilities handle it like APTS_D
+        all_config.trainer.apts_d = True
 
         optimizer_obj = APTS_PINN(
             params=model.parameters(),


### PR DESCRIPTION
## Summary
- Implement a dedicated `APTS_PINN.step` that trains locally on subdomains while evaluating global updates on the full domain
- Register APTS_PINN as an APTS variant in `trainer_setup` for downstream compatibility

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68931189415483228d9550820c6cb6dd