### PR TITLE
Ensure gradient views remain valid during manual aggregation

### DIFF
--- a/src/dd4ml/optimizers/apts_base.py
+++ b/src/dd4ml/optimizers/apts_base.py
@@ -5,7 +5,7 @@ import time
 
 import torch
 import torch.distributed as dist
-from torch.nn.utils import parameters_to_vector, vector_to_parameters
+from torch.nn.utils import parameters_to_vector
 from torch.optim.optimizer import Optimizer
 
 from dd4ml.utility import (
@@ -273,10 +273,20 @@ class APTS_Base(Optimizer):
                     flat_grad = self.glob_grad_to_vector()
                     dist.all_reduce(flat_grad, op=dist.ReduceOp.SUM)
                     flat_grad.div_(self.nr_models)
-                    # unpack back into each parameter's grad
-                    vector_to_parameters(
-                        flat_grad, [p.grad for p in self.model.parameters()]
-                    )
+                    # unpack back into each parameter's grad without creating new tensors
+                    offset = 0
+                    for p in self.model.parameters():
+                        if p.grad is None:
+                            continue
+                        numel = p.grad.numel()
+                        segment = flat_grad.narrow(0, offset, numel)
+                        offset += numel
+                        segment_view = segment.view_as(p)
+                        # copy into existing gradient while preserving its stride
+                        if p.grad.is_contiguous():
+                            p.grad.copy_(segment_view)
+                        else:
+                            p.grad.as_strided(p.shape, p.grad.stride()).copy_(segment_view)
 
             self.grad_evals += 1.0  # Count global gradient evaluation
         if self.nr_models > 1:


### PR DESCRIPTION
## Summary
- Avoid reassigning gradients when averaging for non-DDP models
- Copy flattened gradients into existing tensors while preserving stride

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6895c73146708322a90b772e22dc401d