### PR TITLE
Add configurable contiguous subdomain splitting

### DIFF
--- a/tests/config_files/config_apts_pinn.yaml
+++ b/tests/config_files/config_apts_pinn.yaml
@@ -3,8 +3,8 @@ metric:
   name: train_loss
   goal: minimize
 parameters:
-  optimizer: 
-    value: "apts_pinn" 
+  optimizer:
+    value: "apts_pinn"
   batch_size:
     value: 128
   effective_batch_size:
@@ -35,17 +35,17 @@ parameters:
     value: 1
   max_iters:
     value: 10 # for Transformers
-  epochs: 
+  epochs:
     value: 5
-  delta: 
+  delta:
     value: 0.1
-  min_delta: 
+  min_delta:
     value: 0.001
   max_delta:
     value: 1.0
-  dataset_name: 
-    value: "allencahn1d" 
-  model_name: 
+  dataset_name:
+    value: "allencahn1d"
+  model_name:
     value: "pinn_ffnn"
   criterion:
     value: "pinn_allencahn"
@@ -73,3 +73,5 @@ parameters:
     value: "lssr1_tr"
   paper_tr_update:
     value: True
+  contiguous_subdomains:
+    value: False


### PR DESCRIPTION
## Summary
- allow trainers to split PINN datasets into rank-aligned contiguous subdomains
- skip DistributedSampler when using contiguous subdomains to avoid interleaved data
- expose `contiguous_subdomains` parameter in configuration files (example updated)

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899997cbcec8322bf9cc1204e2373fc