### PR TITLE
Avoid duplicating boundary points in Allen-Cahn dataset

### DIFF
--- a/src/dd4ml/datasets/pinn_allencahn.py
+++ b/src/dd4ml/datasets/pinn_allencahn.py
@@ -23,19 +23,23 @@ class AllenCahn1DDataset(BaseDataset):
 
     def _generate_points(self):
         cfg = self.config
-        # Interior points
-        interior = torch.linspace(
-            cfg.low, cfg.high, cfg.n_interior, dtype=torch.float32
-        ).unsqueeze(1)
+        # Interior points (exclude boundary endpoints)
+        interior = (
+            torch.linspace(
+                cfg.low, cfg.high, cfg.n_interior + 2, dtype=torch.float32
+            )[1:-1]
+            .unsqueeze(1)
+        )
+
         # Boundary points
         boundary = torch.tensor([[cfg.low], [cfg.high]], dtype=torch.float32)
 
-        # Combine data and masks
-        data = torch.cat([boundary, interior], dim=0)
+        # Combine data and masks (interior first, boundary last)
+        data = torch.cat([interior, boundary], dim=0)
         mask = torch.cat(
             [
-                torch.ones(len(boundary), 1),  # boundary flags
                 torch.zeros(len(interior), 1),  # interior flags
+                torch.ones(len(boundary), 1),  # boundary flags
             ],
             dim=0,
         )

--- a/tests/test_pinn_subdomains.py
+++ b/tests/test_pinn_subdomains.py
@@ -18,6 +18,12 @@ def test_split_domain():
     # first subdomain should start at global low, last at global high
     assert torch.isclose(subs[0].x_boundary[0], torch.tensor([cfg.low]))
     assert torch.isclose(subs[-1].x_boundary[-1], torch.tensor([cfg.high]))
+    for sub in subs:
+        # Each subdomain should contain n_interior + 2 total points
+        assert len(sub) == sub.config.n_interior + sub.config.n_boundary
+        all_points = torch.cat([sub.x_interior, sub.x_boundary])
+        # Interior points should exclude boundaries (no duplicates)
+        assert torch.unique(all_points).numel() == all_points.numel()
 
 
 def _run_apts_pinn(rank: int, world_size: int, epochs: int):


### PR DESCRIPTION
## Summary
- generate interior points without endpoints for the Allen-Cahn dataset
- keep boundaries separate and mask them explicitly
- add tests checking each subdomain has expected unique points

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899aed88e0483228cfe5e42f3c30d7d