### PR TITLE
Fix PINN subdomain splitting for Allen-Cahn dataset

### DIFF
--- a/src/dd4ml/datasets/pinn_allencahn.py
+++ b/src/dd4ml/datasets/pinn_allencahn.py
@@ -23,10 +23,12 @@ class AllenCahn1DDataset(BaseDataset):
 
     def _generate_points(self):
         cfg = self.config
-        # Interior points
+        # Interior points exclude boundaries
+        step = (cfg.high - cfg.low) / (cfg.n_interior + 1)
         interior = torch.linspace(
-            cfg.low, cfg.high, cfg.n_interior, dtype=torch.float32
+            cfg.low + step, cfg.high - step, cfg.n_interior, dtype=torch.float32
         ).unsqueeze(1)
+
         # Boundary points
         boundary = torch.tensor([[cfg.low], [cfg.high]], dtype=torch.float32)
 

--- a/src/dd4ml/utility/trainer_setup.py
+++ b/src/dd4ml/utility/trainer_setup.py
@@ -101,10 +101,11 @@ def get_config_model_and_trainer(args, wandb_config):
 
         if rank > 0:
             def _remove_left_boundary(ds):
-                eps = (ds.config.high - ds.config.low) / ds.config.n_interior
-                mask = ds.data[:, 0] > ds.config.low + eps / 2
+                mask = ds.data[:, 0] > ds.config.low
                 ds.data = ds.data[mask]
                 ds.boundary_mask = ds.boundary_mask[mask]
+                if hasattr(ds, "x_boundary"):
+                    ds.x_boundary = ds.x_boundary[1:]
 
             _remove_left_boundary(dataset)
             _remove_left_boundary(test_dataset)


### PR DESCRIPTION
## Summary
- generate Allen-Cahn interior points without including domain boundaries
- cleanly drop left boundary for non-zero ranks when splitting dataset

## Testing
- `PYTHONPATH=src pytest tests/test_pinn_subdomains.py::test_split_domain -q`


------
https://chatgpt.com/codex/tasks/task_e_6899ba1e562c83229087a581d09a5ed4