### PR TITLE
Sort subdomain points and expose exclusive flag

### DIFF
--- a/src/dd4ml/datasets/pinn_allencahn.py
+++ b/src/dd4ml/datasets/pinn_allencahn.py
@@ -32,7 +32,9 @@ class AllenCahn1DDataset(BaseDataset):
         # Boundary points
         boundary = torch.tensor([[cfg.low], [cfg.high]], dtype=torch.float32)
 
-        # Combine data and masks
+        # Combine data and masks and sort by the coordinate value so that
+        # downstream consumers (e.g. different ranks in a distributed run)
+        # see points in increasing order.
         data = torch.cat([boundary, interior], dim=0)
         mask = torch.cat(
             [
@@ -41,9 +43,9 @@ class AllenCahn1DDataset(BaseDataset):
             ],
             dim=0,
         )
-
-        self.data = data
-        self.boundary_mask = mask
+        sort_idx = torch.argsort(data[:, 0])
+        self.data = data[sort_idx]
+        self.boundary_mask = mask[sort_idx]
         self.x_interior = interior
         self.x_boundary = boundary
 

--- a/src/dd4ml/trainer.py
+++ b/src/dd4ml/trainer.py
@@ -85,6 +85,7 @@ class Trainer:
         C.glob_opt = None
         C.overlap = 0.0
         C.contiguous_subdomains = False
+        C.exclusive = True
         C.adjust_batch_size_every_iters = 10000  # for use with LLMs and LSSR1_TR
         return C
 

--- a/src/dd4ml/utility/trainer_setup.py
+++ b/src/dd4ml/utility/trainer_setup.py
@@ -94,8 +94,9 @@ def get_config_model_and_trainer(args, wandb_config):
     ):
         world_size = dist.get_world_size() if dist.is_initialized() else 1
         rank = dist.get_rank() if dist.is_initialized() else 0
-        train_splits = dataset.split_domain(world_size, exclusive=True)
-        test_splits = test_dataset.split_domain(world_size, exclusive=True)
+        exclusive = getattr(all_config.trainer, "exclusive", True)
+        train_splits = dataset.split_domain(world_size, exclusive=exclusive)
+        test_splits = test_dataset.split_domain(world_size, exclusive=exclusive)
         dataset = train_splits[rank]
         test_dataset = test_splits[rank]
 

--- a/tests/config_files/config_apts_pinn.yaml
+++ b/tests/config_files/config_apts_pinn.yaml
@@ -75,3 +75,5 @@ parameters:
     value: True
   contiguous_subdomains:
     value: True
+  exclusive:
+    value: True

--- a/tests/test_pinn_subdomains.py
+++ b/tests/test_pinn_subdomains.py
@@ -32,6 +32,15 @@ def test_split_domain_exclusive():
     assert torch.unique(all_points).numel() == all_points.numel()
 
 
+def test_split_domain_order():
+    cfg = AllenCahn1DDataset.get_default_config()
+    ds = AllenCahn1DDataset(cfg)
+    subs = ds.split_domain(2, exclusive=True)
+    for sub in subs:
+        xs = sub.data[:, 0]
+        assert torch.all(torch.diff(xs) >= 0), "Subdomain points are not ordered"
+
+
 def _run_apts_pinn(rank: int, world_size: int, epochs: int):
     from dd4ml.models.ffnn.pinn_ffnn import PINNFFNN
     from dd4ml.optimizers.apts_pinn import APTS_PINN


### PR DESCRIPTION
## Summary
- ensure PINN Allen-Cahn subdomain samples are sorted by coordinate for deterministic ordering on each rank
- allow dataset domain splitting to honour configurable `exclusive` flag via trainer config and sweep configs
- test subdomain ordering logic

## Testing
- `PYTHONPATH=src pytest tests/test_pinn_subdomains.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6899dc69f9a48322b3e6f4de70ccded3