### PR TITLE
Fix dtype mismatch in PINN Allen-Cahn loss

### DIFF
--- a/src/dd4ml/utility/pinn_allencahn_loss.py
+++ b/src/dd4ml/utility/pinn_allencahn_loss.py
@@ -43,9 +43,18 @@ class AllenCahnPINNLoss(nn.Module):
         residual = -grad2_u + u_pred**3 - u_pred
         interior = (residual.squeeze() ** 2) * (1 - boundary_flag.squeeze())
 
-        # Only compute bc_val for actual boundary points
-        bc_left = torch.isclose(x.squeeze(), torch.tensor(self.low, device=x.device))
-        bc_right = torch.isclose(x.squeeze(), torch.tensor(self.high, device=x.device))
+        # Only compute bc_val for actual boundary points.  ``torch.tensor`` defaults
+        # to ``float32`` which causes dtype mismatches when ``x`` is ``float64``.
+        # Explicitly match the dtype of ``x`` so ``torch.isclose`` works for both
+        # single- and double-precision tensors.
+        bc_left = torch.isclose(
+            x.squeeze(),
+            torch.tensor(self.low, device=x.device, dtype=x.dtype),
+        )
+        bc_right = torch.isclose(
+            x.squeeze(),
+            torch.tensor(self.high, device=x.device, dtype=x.dtype),
+        )
 
         bc_val = torch.zeros_like(x.squeeze())
         bc_val[bc_left] = 1.0


### PR DESCRIPTION
## Summary
- avoid float32/float64 mismatch when evaluating boundary conditions in `AllenCahnPINNLoss`

## Testing
- `PYTHONPATH=src pytest tests/test_overlap.py -q`
- `PYTHONPATH=src pytest tests/test_pinn_subdomains.py -q` *(fails: assert 100002 == 12)*

------
https://chatgpt.com/codex/tasks/task_e_689adc7b60748322b29e9e4d8453da93