### PR TITLE
fix: ensure APTS optimizers use double precision in PINN training

### DIFF
--- a/src/dd4ml/trainer.py
+++ b/src/dd4ml/trainer.py
@@ -1002,6 +1002,15 @@ class Trainer:
         """Simplified epoch loop for PINN datasets, with adaptive and callback logic."""
         # ensure model and loss operate in double precision for PINN training
         self.model = self.model.double()
+        if hasattr(self.optimizer, "loc_model"):
+            # APTS-based optimizers keep a separate local model that
+            # is cloned during initialisation.  When switching the main
+            # model to ``float64`` we must also convert this local copy,
+            # otherwise forward passes inside the optimizer will mix
+            # ``float32`` weights with ``float64`` inputs, triggering
+            # dtype mismatch errors.
+            self.optimizer.loc_model = self.optimizer.loc_model.double()
+
         if hasattr(self.criterion, "to"):
             self.criterion = self.criterion.to(torch.float64)
 


### PR DESCRIPTION
## Summary
- convert APTS optimizer local model to float64 during PINN epoch run to avoid dtype mismatch
- keep loss function in double precision

## Testing
- `pytest tests/test_pinn_subdomains.py::test_apts_pinn_dataset_not_split -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch --index-url https://download.pytorch.org/whl/cpu` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_689ae4822fc08322a3d09185bdf67054