### PR TITLE
Enable subdomain overlap in APTS_PINN optimizer

### DIFF
--- a/src/dd4ml/utility/trainer_setup.py
+++ b/src/dd4ml/utility/trainer_setup.py
@@ -311,6 +311,7 @@ def get_config_model_and_trainer(args, wandb_config):
             max_glob_iters=all_config.trainer.max_glob_iters,
             tol=all_config.trainer.tol,
             num_subdomains=all_config.trainer.num_subdomains,
+            overlap=all_config.trainer.overlap,
             **all_config.trainer.apts_params,
         )
     elif optimizer_name == "lssr1_tr":


### PR DESCRIPTION
## Summary
- add overlap-aware subdomain bounds and mask utilities to APTS_PINN
- wire overlap parameter through trainer setup
- test that subdomain masks share points when overlap > 0

## Testing
- `python -m py_compile src/dd4ml/optimizers/apts_pinn.py tests/test_pinn_subdomains.py src/dd4ml/utility/trainer_setup.py`
- `pytest tests/test_pinn_subdomains.py::test_apts_pinn_subdomain_overlap` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_689ca2f3916c8322934363d5eba75b56