### PR TITLE
Fix input feature inference for AllenCahn time dataset

### DIFF
--- a/src/dd4ml/utility/trainer_setup.py
+++ b/src/dd4ml/utility/trainer_setup.py
@@ -39,6 +39,7 @@ def get_config_model_and_trainer(args, wandb_config):
     Create and return the standardized configuration, model, and trainer.
     """
     from dd4ml.datasets.pinn_allencahn import AllenCahn1DDataset
+    from dd4ml.datasets.pinn_allencahn_time import AllenCahn1DTimeDataset
     from dd4ml.datasets.pinn_poisson import Poisson1DDataset
     from dd4ml.datasets.pinn_poisson2d import Poisson2DDataset
     from dd4ml.datasets.pinn_poisson3d import Poisson3DDataset
@@ -116,10 +117,20 @@ def get_config_model_and_trainer(args, wandb_config):
         and all_config.model.input_features is not None
         and isinstance(
             dataset,
-            (Poisson1DDataset, Poisson2DDataset, Poisson3DDataset, AllenCahn1DDataset),
+            (
+                Poisson1DDataset,
+                Poisson2DDataset,
+                Poisson3DDataset,
+                AllenCahn1DDataset,
+                AllenCahn1DTimeDataset,
+            ),
         )
     ):
-        sample_x, _ = dataset[0]
+        sample = dataset[0]
+        if isinstance(dataset, AllenCahn1DTimeDataset):
+            sample_x = torch.cat(sample[:2], dim=0)
+        else:
+            sample_x = sample[0]
         all_config.model.input_features = sample_x.numel()
 
     # Adjust config for text models (e.g., GPT).

--- a/tests/test_trainer_setup_allencahn_time.py
+++ b/tests/test_trainer_setup_allencahn_time.py
@@ -1,0 +1,12 @@
+import torch
+from dd4ml.utility.trainer_setup import get_config_model_and_trainer
+
+
+def test_trainer_setup_infers_input_features_allencahn_time():
+    args = {
+        "dataset_name": "allencahn1d_time",
+        "model_name": "pinn_ffnn",
+        "optimizer": "apts_pinn",
+    }
+    cfg, model, trainer = get_config_model_and_trainer(args, wandb_config=None)
+    assert cfg.model.input_features == 2


### PR DESCRIPTION
## Summary
- handle AllenCahn1DTimeDataset when inferring PINN model input dimension
- add regression test ensuring trainer setup sets input features to 2 for time-dependent Allen–Cahn runs

## Testing
- `pytest tests/test_trainer_setup_allencahn_time.py::test_trainer_setup_infers_input_features_allencahn_time -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_689de0c35e848322975694141f8e63cb